### PR TITLE
Fix building on gcc 14 (#2644)

### DIFF
--- a/src/knnmisc.cpp
+++ b/src/knnmisc.cpp
@@ -8,6 +8,7 @@
 // did not, you can find it at http://www.gnu.org/
 //
 
+#include <algorithm>
 #include "knnmisc.h"
 #include "knnlib.h"
 #include "exprtraits.h"


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix 

**Description of the Change:**
Fix building on gcc-14 (ArchLinux, Fedora 40, ...)

**Related Issue (provide the link):**
#2644